### PR TITLE
Feature : RsyslogRule 추가 및 코드 리팩토링 진행

### DIFF
--- a/src/LogDaemon.cpp
+++ b/src/LogDaemon.cpp
@@ -14,7 +14,7 @@ void LogCollectorDaemon::Run()
     prctl(PR_SET_NAME, "ManLab Log", 0, 0, 0);
 
     std::string logPath = "/var/log/manlab.log";
-    std::string ruleSetPath = "Manlab/conf/RsyslogRuleSet.yaml";
+    std::string ruleSetPath = "/Manlab/conf/RsyslogRuleSet.yaml";
 
     RsyslogManager rsyslog(logPath, ruleSetPath);
 

--- a/src/RsyslogManager.cpp
+++ b/src/RsyslogManager.cpp
@@ -8,6 +8,7 @@
 #include <regex>
 #include <thread>
 #include <chrono>
+#include <ctime>
 
 #include <yaml-cpp/yaml.h>
 
@@ -16,24 +17,38 @@ RsyslogManager::RsyslogManager(const std::string& logPath, const std::string& ru
     , mRsyslogRuleSet(loadRsyslogRuleSet(ruleSetPath))
 {}
 
+// 로그 분석을 위한 timestamp 변환
+time_t RsyslogManager::ParseTime(const std::string& timestamp) {
+    struct tm tm{};
+    strptime(timestamp.c_str(), "%b %d %H:%M:%S", &tm);
+    
+    // 연도, 월 기본값 보정 (옵션)
+    time_t now = time(nullptr);
+    struct tm* now_tm = localtime(&now);
+    tm.tm_year = now_tm->tm_year;
+    tm.tm_mon = now_tm->tm_mon;
+
+    return mktime(&tm);
+}
+
 // RsyslogRuleSet 파싱
-std::unordered_set<std::string> RsyslogManager::loadRsyslogRuleSet(const std::string& filename)
+std::unordered_map<std::string, std::unordered_set<std::string>> RsyslogManager::loadRsyslogRuleSet(const std::string& filename)
 {
-    std::unordered_set<std::string> result;
+    std::unordered_map<std::string, std::unordered_set<std::string>> result;
 
     try
     {
         YAML::Node config = YAML::LoadFile(filename);
 
-        if (!config["sudousers"] || !config["sudousers"].IsSequence())
-        {
-            std::cerr << "[ERROR] Invalid YAML RsyslogRuleSet format\n";
-            return result;
-        }
+        for (auto it = config.begin(); it != config.end(); ++it) {
+            std::string ruleKey = it->first.as<std::string>();
+            const YAML::Node& ruleList = it->second;
 
-        for (const auto& user : config["sudousers"])
-        {
-            result.insert(user.as<std::string>());
+            if (ruleList.IsSequence()) {
+                for (const auto& item : ruleList) {
+                    result[ruleKey].insert(item.as<std::string>());
+                }
+            }
         }
     }
     catch (const YAML::Exception& e)
@@ -47,7 +62,7 @@ std::unordered_set<std::string> RsyslogManager::loadRsyslogRuleSet(const std::st
 // 로그 한 줄을 파싱하여 LogEntry 구조로 반환
 std::optional<LogEntry> RsyslogManager::parseLogLine(const std::string& line)
 {
-    std::regex oldFmt(R"((\w{3}\s+\d+\s[\d:]+)\s(\S+)\s([\w\-]+):\s(.+))");
+    std::regex oldFmt(R"((\w{3}\s+\d+\s[\d:]+)\s(\S+)\s([^\s:]+):\s(.+))");
     std::regex newFmt(R"((\d{4}-\d{2}-\d{2}T[\d:.+-]+)\s(\S+)\s(\S+):\s(.+))");
 
     std::smatch match;
@@ -82,7 +97,28 @@ void RsyslogManager::RsyslogRun()
             auto entry = parseLogLine(line);
             if (entry)
             {
-                auto result = AnalyzeSudoLog(*entry, mRsyslogRuleSet);
+                //추가해야됨
+                mRecentLogs.push_back(*entry);
+
+                //추가해야됨
+                // 개수 기준으로 오래된 로그 삭제 (10개 초과 시 제거)
+                if (mRecentLogs.size() > MAX_RECENT_LOGS) {
+                    mRecentLogs.pop_front();
+                }
+
+                AnalysisResult result{false, "", ""};
+
+                //수정 및 추가 해야됨
+                result = AnalyzePasswordFailureLog(*entry);
+
+                if (!result.isMalicious)
+                {
+                    result = AnalyzeSudoLog(*entry, mRsyslogRuleSet["sudousers"]);
+                }
+                if (!result.isMalicious)
+                {
+                    result = AnalyzePasswdChangeLog(*entry, mRecentLogs, mRsyslogRuleSet["passwdchangers"]);
+                }
 
                 if (result.isMalicious)
                 {

--- a/src/RsyslogManager.h
+++ b/src/RsyslogManager.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include <string>       // 문자열 클래스
-#include <optional>     // std::optional 사용
+#include <string>
+#include <optional>
+#include <deque>
 #include <unordered_set>
+#include <unordered_map>
 
 // 파싱된 로그 항목을 담는 구조체
 struct LogEntry
@@ -26,13 +28,17 @@ class RsyslogManager
 {
 public:
     RsyslogManager(const std::string& logPath, const std::string& ruleSetPath);
-
+    
+    static time_t ParseTime(const std::string& timestamp);
     void RsyslogRun();
 
 private:
-    std::string mLogPath;
-    std::unordered_set<std::string> mRsyslogRuleSet;
+    static constexpr size_t MAX_RECENT_LOGS = 10;
 
-    std::unordered_set<std::string> loadRsyslogRuleSet(const std::string& filename);
+    std::string mLogPath;
+    std::unordered_map<std::string, std::unordered_set<std::string>> mRsyslogRuleSet;
+
+    std::deque<LogEntry> mRecentLogs;
+    std::unordered_map<std::string, std::unordered_set<std::string>> loadRsyslogRuleSet(const std::string& filename);
     std::optional<LogEntry> parseLogLine(const std::string& line);
 };

--- a/src/RsyslogRule.cpp
+++ b/src/RsyslogRule.cpp
@@ -3,11 +3,18 @@
 #include <iostream>
 #include <regex>
 
+//비인가 사용자의 sudo 사용 탐지
 AnalysisResult AnalyzeSudoLog(const LogEntry& entry, const std::unordered_set<std::string>& rsyslogRuleSet)
 {
-    AnalysisResult result{ false, "" };
+    AnalysisResult result{ false, "", "" };
 
     if (entry.process.find("sudo") == std::string::npos || entry.message.find("COMMAND=") == std::string::npos)
+    {
+        return result;
+    }
+
+    //sudo 패스워드 실패시 탐지 X
+    if (entry.message.find("incorrect password attempts") != std::string::npos)
     {
         return result;
     }
@@ -22,20 +29,128 @@ AnalysisResult AnalyzeSudoLog(const LogEntry& entry, const std::unordered_set<st
 
         if (rsyslogRuleSet.find(user) == rsyslogRuleSet.end())
         {
-            // 디버깅용 알림
-            // std::cout << "\033[1;31m[ALERT] Unauthorized sudo usage!\033[0m\n";
-            // std::cout << "  user    : " << user << "\n";
-            // std::cout << "  command : " << command << "\n";
-
             result.isMalicious = true;
             result.type = "unauthorized_sudo";
             result.description = "비인가 사용자 " + user + "가 sudo 명령 사용 : " + command;
         }
-        else
-        {
-            // 디버깅용 알림
-            // std::cout << "[INFO] Authorized sudo by " << user << ": " << command << "\n";
+    }
+    return result;
+}
+
+//다른 사용자의 passwd 변경 탐지
+AnalysisResult AnalyzePasswdChangeLog(const LogEntry& entry, const std::deque<LogEntry>& recentLogs, const std::unordered_set<std::string>& rsyslogRuleSet)
+{
+    AnalysisResult result{ false, "", "" };
+    std::regex regex(R"(pam_unix\(passwd:chauthtok\): password changed for (\w+))");
+    std::smatch match;
+
+    if (entry.process.find("passwd") != std::string::npos &&
+        entry.message.find("password changed for") != std::string::npos &&
+        std::regex_search(entry.message, match, regex))
+    {
+        std::string targetUser = match[1];
+        std::string changer = "unknown";
+
+        // recentLogs를 역순 탐색하여 sudo 로그에서 passwd 실행자를 찾는다
+        for (auto it = recentLogs.rbegin(); it != recentLogs.rend(); ++it) {
+            const LogEntry& log = *it;
+            if (log.process.find("sudo") != std::string::npos &&
+                log.message.find("COMMAND=") != std::string::npos &&
+                log.message.find("passwd " + targetUser) != std::string::npos)
+            {
+                std::smatch sudoMatch;
+                std::regex sudoRegex(R"((\w+)\s+:\s.*COMMAND=(.+))");
+                if (std::regex_search(log.message, sudoMatch, sudoRegex)) {
+                    changer = sudoMatch[1];
+                    break;
+                }
+            }
         }
+
+        if (rsyslogRuleSet.find(changer) == rsyslogRuleSet.end())
+        {
+            result.isMalicious = true;
+            result.type = "unauthorized_passwd_change";
+            result.description = changer + " (추정 사용자)가 '" + targetUser + "'의 비밀번호를 변경함";
+        }
+    }
+
+    return result;
+}
+
+//passwd 반복 실패 탐지
+AnalysisResult AnalyzePasswordFailureLog(const LogEntry& entry) {
+    static std::unordered_map<std::string, std::pair<int, time_t>> failureMap;
+    const int THRESHOLD = 3;
+    const int TIME_WINDOW = 60;
+    AnalysisResult result{ false, "", "" };
+
+    // 1. sudo: N incorrect password attempts
+    std::regex sudoPattern(R"((\w+)\s+:\s+(\d+)\s+incorrect password attempts)");
+
+    // 2. 콘솔 로그인 실패
+    std::regex consolPattern(R"(FAILED LOGIN \(\d+\) on '.+' FOR '(\w+)', Authentication failure)");
+
+    // 3. GUI 첫번째 실패 이후 탐지 "message repeated N times: [ pam_unix(...) ]""
+    std::regex guiPattern(R"(message repeated (\d+) times: \[ pam_unix\([^\)]+:(?:auth|account)\): authentication failure;.*user=([a-zA-Z0-9_\-]+)\])");
+ 
+    // 4. pam_unix 인증 실패 (su/gdm/ssh 등)
+    std::regex pamPattern(R"(pam_unix\((?!login:)[^\)]+:(?:auth|account)\): authentication failure;.*user=([a-zA-Z0-9_\-]+))");
+
+
+    std::smatch match;
+    bool matched = false;
+    std::string username;
+    int failCount = 0;
+
+    // 1. sudo 실패 로그 (가장 우선 감지)
+    if (entry.process == "sudo" && std::regex_search(entry.message, match, sudoPattern)) {
+        username = match[1];
+        failCount = std::stoi(match[2]);
+        matched = true;
+    }
+
+    // 2. GUI 1번 실패 이후 N
+    else if (std::regex_search(entry.message, match, guiPattern)) {
+        failCount = std::stoi(match[1]);
+        username = match[2];
+        matched = true;
+    }
+
+    // 3. 콘솔 로그인
+    else if (std::regex_search(entry.message, match, consolPattern)) {
+        username = match[1];
+        failCount = 1;
+        matched = true;
+    }
+
+    // 4. pam_unix
+    else if (std::regex_search(entry.message, match, pamPattern) && entry.process != "login") {
+        username = match[1];
+        failCount = 1;
+        matched = true;
+    }
+
+    // 실패한 사용자 감지 안 되면 종료
+    if (!matched || username.empty())
+        return result;
+
+    // 실패 누적 처리
+    time_t now = RsyslogManager::ParseTime(entry.timestamp);
+    auto& [count, firstTime] = failureMap[username];
+
+    if (count == 0 || now - firstTime > TIME_WINDOW) {
+        count = failCount;
+        firstTime = now;
+    } else {
+        count += failCount;
+    }
+
+    if (count >= THRESHOLD) {
+        count = 0;  // 리셋
+        result.isMalicious = true;
+        result.type = "brute_force_password_failure";
+        result.description = "1분 내 " + std::to_string(THRESHOLD) + "회 이상 인증 실패: 사용자 '" + username + "'";
     }
 
     return result;

--- a/src/RsyslogRule.h
+++ b/src/RsyslogRule.h
@@ -6,3 +6,5 @@
 #include "RsyslogManager.h"  // LogEntry, AnalysisResult 사용
 
 AnalysisResult AnalyzeSudoLog(const LogEntry& entry, const std::unordered_set<std::string>& rsyslogRuleSet);
+AnalysisResult AnalyzePasswdChangeLog(const LogEntry& entry, const std::deque<LogEntry>& recentLogs, const std::unordered_set<std::string>& rsyslogRuleSet);
+AnalysisResult AnalyzePasswordFailureLog(const LogEntry& entry);


### PR DESCRIPTION
## 📌 관련 이슈

* Closes #33 Closes #42 

## ✨ 작업 내용

* 다른 사용자의 비밀번호 변경 탐지 룰 작성
   -> deque를 활용한 다중 로그 분석 기법 추가
* GUI, 콘솔 , Su, Sudo 등의 비밀번호 반복 실패 (1분당 3회 이상 실패) 탐지 룰 작성
   -> timestamp 기반 누적 실패 탐지
* 비인가 사용자의 sudo 사용 탐지 일부 로직 수정
* 룰 추가와 변경에 따른 일부 코드 리팩토링
* LogDaemon.cpp에 적힌 RsyslogRuleSet 경로 수정

## 🚨 중요 변경 사항 (⚠️ 필요시 체크)

* [x] RsyslogRule 2개 추가

## 🔍 To Reviews

* 2가지의 룰이 추가 되었습니다. 룰 추가와 관련된 일부 기능이 추가되었으며, 일부 코드 리팩토링 진행하였습니다.
* sudo 로그인 실패시에도 sudo 로그가 기록되어 비인가 사용자의 sudo 사용으로 잘못 탐지 되던 것을 수정하였습니다. 

## ✅ 체크리스트

* [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
* [x] Merge 하는 브랜치가 올바른가? (`main` 브랜치에 실수로 PR 생성 금지)
* [x] 팀의 코딩 컨벤션을 준수하는가?
* [x] PR과 관련 없는 변경 사항이 들어가지는 않았는가?
* [x] 내 코드에 대한 자기 검토가 충분히 되었는가?
* [x] Reviewers, Assignees, Labels, Project, Milestone은 적절하게 선택하였는가?
* [x] 관련된 issue를 닫아야 하는지 점검해보고 적용하였는가?

## 🚀 추가 코멘트
