### PR TITLE
feat: 리포트 관련 로직 추가 및 시각화 수정

### DIFF
--- a/src/server/AuditLogManager.cpp
+++ b/src/server/AuditLogManager.cpp
@@ -252,8 +252,7 @@ void AuditLogManager::Run()
                         else
                             lar.timestamp = record.MsgId;
 
-                        lar.uid = record.Fields.count("auid") > 0 ? record.Fields.at("auid") : "";
-                        lar.bIsSuccess = true;
+                        lar.username = record.Fields.count("auid") > 0 ? record.Fields.at("auid") : "";
                         lar.originalLogPath = PATH_AUDITLOG;
                         lar.rawLine = record.RawLine;
 

--- a/src/server/DBManager.cpp
+++ b/src/server/DBManager.cpp
@@ -45,8 +45,7 @@ DBManager::DBManager()
             sqlite_orm::make_column("Type", &LogAnalysisResult::type),
             sqlite_orm::make_column("Description", &LogAnalysisResult::description),
             sqlite_orm::make_column("Timestamp", &LogAnalysisResult::timestamp),
-            sqlite_orm::make_column("UID", &LogAnalysisResult::uid),
-            sqlite_orm::make_column("IsSuccess", &LogAnalysisResult::bIsSuccess),
+            sqlite_orm::make_column("Username", &LogAnalysisResult::username),
             sqlite_orm::make_column("OriginalLogPath", &LogAnalysisResult::originalLogPath),
             sqlite_orm::make_column("RawLine", &LogAnalysisResult::rawLine)))),
                                  

--- a/src/server/DBManager.h
+++ b/src/server/DBManager.h
@@ -48,8 +48,7 @@ struct LogAnalysisResult
     std::string type;
     std::string description;
     std::string timestamp;
-    std::string uid;
-    bool bIsSuccess;
+    std::string username;
     std::string originalLogPath;
     std::string rawLine;
 };
@@ -114,8 +113,7 @@ using StorageLogAnalysisResult = decltype(sqlite_orm::make_storage("",
         sqlite_orm::make_column("Type", &LogAnalysisResult::type),
         sqlite_orm::make_column("Description", &LogAnalysisResult::description),
         sqlite_orm::make_column("Timestamp", &LogAnalysisResult::timestamp),
-        sqlite_orm::make_column("UID", &LogAnalysisResult::uid),
-        sqlite_orm::make_column("IsSuccess", &LogAnalysisResult::bIsSuccess),
+        sqlite_orm::make_column("Username", &LogAnalysisResult::username),
         sqlite_orm::make_column("OriginalLogPath", &LogAnalysisResult::originalLogPath),
         sqlite_orm::make_column("RawLine", &LogAnalysisResult::rawLine))));
 

--- a/src/server/GmailClient.cpp
+++ b/src/server/GmailClient.cpp
@@ -56,7 +56,7 @@ bool GmailClient::Run(const std::string &file)
         curl_easy_setopt(mCurl, CURLOPT_MAIL_RCPT, recipients);
 
         mime = curl_mime_init(mCurl);
-        std::string body = "만랩 로그 분석 리포트입니다.";
+        std::string body = "설정하신 ReportConfig.ini 내용에 따라 생성된 만랩 정기 리포트입니다.";
 
         // 본문
         part = curl_mime_addpart(mime);
@@ -74,7 +74,7 @@ bool GmailClient::Run(const std::string &file)
         struct curl_slist *headers = nullptr;
         headers = curl_slist_append(headers, ("To: " + mTo).c_str());
         headers = curl_slist_append(headers, ("From: " + mFrom).c_str());
-        headers = curl_slist_append(headers, "Subject: 만랩 로그 분석 리포트");
+        headers = curl_slist_append(headers, "Subject: 만랩 정기 리포트");
         curl_easy_setopt(mCurl, CURLOPT_HTTPHEADER, headers);
 
         curl_easy_setopt(mCurl, CURLOPT_MIMEPOST, mime);

--- a/src/server/GmailClient.cpp
+++ b/src/server/GmailClient.cpp
@@ -1,11 +1,11 @@
 #include "GmailClient.h"
 #include <stdlib.h>
-#include <iostream> // 디버깅용
 #include <openssl/evp.h>
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
 #include <vector>
 #include <cstring>
+#include <spdlog/spdlog.h>
 
 // 컴파일 시 이 부분을 주석 처리 후 key, iv를 붙여넣으시면 됩니다.
 const unsigned char key[32] = {};
@@ -16,14 +16,15 @@ GmailClient::GmailClient(const std::string &to)
     mCurl = curl_easy_init();
     if (!mCurl)
     {
-        std::cerr << "Failed to init curl" << std::endl;
         // TODO : 에러 처리 로직
+        spdlog::error("Failed to init curl.");
         return;
     }
 
     mTo = to;
     std::string encryptedAppPassword = "pYJ53KhgQmK4T8HLiqWggNchno0fQ+ZAhFX8NUIH2cY=";
     mAppPassword = GmailClient::DecryptAppPassword(encryptedAppPassword);
+    spdlog::info("GmailClient() completed.");
 }
 
 GmailClient::~GmailClient()
@@ -80,8 +81,7 @@ bool GmailClient::Run(const std::string &file)
         CURLcode res = curl_easy_perform(mCurl);
         if (res != CURLE_OK)
         {
-            std::cerr << "curl_easy_perform() failed: " << curl_easy_strerror(res) << std::endl;
-            // TODO : 로깅
+            spdlog::error("curl_easy_perform() failed: ", curl_easy_strerror(res));
             curl_slist_free_all(recipients);
             curl_slist_free_all(headers);
             curl_mime_free(mime);
@@ -89,7 +89,7 @@ bool GmailClient::Run(const std::string &file)
         }
         else
         {
-            std::cout << "Email sent successfully.\n";
+            spdlog::info("Email sent successfully.");
             curl_slist_free_all(recipients);
             curl_slist_free_all(headers);
             curl_mime_free(mime);
@@ -98,6 +98,7 @@ bool GmailClient::Run(const std::string &file)
     }
     else
     {
+        spdlog::error("Failed to init curl.");
         return false;
     }
 }
@@ -118,6 +119,7 @@ std::string GmailClient::DecryptAppPassword(const std::string &appPassword)
 
     if (!success) {
         // TODO : 에러 핸들링
+        spdlog::error("App password decryption failed.");
         return "";
     }
 
@@ -140,10 +142,11 @@ std::string GmailClient::Base64Decode(const std::string &input)
 
     if (len <= 0) {
         // TODO: 에러 처리
+        spdlog::error("Base64 decoding failed.");
         return "";
     }
 
-    // TODO : 로깅 (Base64 Decode successed.)
+    spdlog::debug("Base64 decoding successed.");
     return std::string(buffer.data(), len);
 }
 
@@ -154,26 +157,34 @@ bool GmailClient::AesDecrypt(const unsigned char* ciphertext, int ciphertextLen,
 
     EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
     if (!ctx)
-        // TODO : 로깅 (Failed to create OpenSSL Context.)
+    {
+        spdlog::error("Failed to create OpenSSL Context.");
         return false;
+    }
 
     int len = 0;
 
     if (EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, key, iv) != 1)
-        // TODO : 로깅 (Decryption initialization failed in AES-256-CBC mode.)
+    {
+        spdlog::error("Decryption initialization failed in AES-256-CBC mode.");
         return false;
+    }
 
     if (EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext, ciphertextLen) != 1)
-        // TODO : 로깅 (Decryption failed.)
+    {
+        spdlog::error("Decryption failed.");
         return false;
+    }
     plaintextLen = len;
 
     if (EVP_DecryptFinal_ex(ctx, plaintext + len, &len) != 1)
-        // TODO : 로깅 (Failed to remove padding.)
+    {
+        spdlog::error("Failed to remove padding.");
         return false;
+    }
     plaintextLen += len;
 
     EVP_CIPHER_CTX_free(ctx);
-    // TODO : 로깅 (Decryption successed.)
+    spdlog::debug("Decryption successed.");
     return true;
 }

--- a/src/server/LogStorageManager.cpp
+++ b/src/server/LogStorageManager.cpp
@@ -1,4 +1,5 @@
 #include "LogStorageManager.h"
+#include <spdlog/spdlog.h> 
 
 using namespace std;
 
@@ -12,7 +13,14 @@ LogStorageManager::LogStorageManager()
 void LogStorageManager::Run(LogAnalysisResult& result, bool bIsAudit)
 {
     result.timestamp = convertTimestamp(result.timestamp, bIsAudit);
+    spdlog::debug("result.type : {}", result.type);
+    spdlog::debug("result.description : {}", result.description);
+    spdlog::debug("result.timestamp : {}", result.timestamp);
+    spdlog::debug("result.username : {}", result.username);
+    spdlog::debug("result.originalLogPath : {}", result.originalLogPath);
+    spdlog::debug("result.rawLine : {}", result.rawLine);
     mStorage->insert(result);
+    spdlog::info("Saving to LogAnalysisResultDB has been completed.");
 }
 
 // 타임스탬프 형식 변환('YYYY-MM-DD HH:MM:SS' 형식으로)

--- a/src/server/ReportService.cpp
+++ b/src/server/ReportService.cpp
@@ -34,7 +34,11 @@ bool ReportService::loadEmailSettings()
 
 bool ReportService::Run()
 {
-    loadEmailSettings();
+    if(!loadEmailSettings())
+    {
+        spdlog::info("Failed to load EmailSettings.");
+        return false;
+    }
 
     mCurrentTime = getCurrentTimeString();
     std::string htmlFile = std::string(PATH_LOG_REPORT) + "/Report_" + mCurrentTime.substr(0, 10) + ".html";
@@ -115,11 +119,10 @@ bool ReportService::generateHTML(const std::string &htmlFile, const std::vector<
         <tr>
             <th>Event ID</th>
             <th>Type</th>
-            <th>User ID</th>
-            <th>Timestamp</th>
-            <th>Success</th>
-            <th>Original Log Path</th>
             <th>Description</th>
+            <th>Timestamp</th>
+            <th>Username</th>
+            <th>Original Log Path</th>
         </tr>
     </thead>
     <tbody>
@@ -147,11 +150,10 @@ bool ReportService::generateHTML(const std::string &htmlFile, const std::vector<
             html << "<tr>";
             html << "<td>" << e.id << "</td>";
             html << "<td>" << e.type << "</td>";
-            html << "<td>" << e.uid << "</td>";
-            html << "<td>" << e.timestamp << "</td>";
-            html << "<td>" << (e.bIsSuccess ? "Yes" : "No") << "</td>";
-            html << "<td>" << e.originalLogPath << "</td>";
             html << "<td>" << e.description << "</td>";
+            html << "<td>" << e.timestamp << "</td>";
+            html << "<td>" << e.username << "</td>";
+            html << "<td>" << e.originalLogPath << "</td>";
             html << "</tr>\n";
         }
 

--- a/src/server/ReportService.cpp
+++ b/src/server/ReportService.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>    // close, system
 #include <chrono>     // system_clock 등
 #include <thread>     // sleep
+#include <spdlog/spdlog.h>
 
 using namespace std::chrono;
 using manlab::utils::stripComment;
@@ -52,8 +53,11 @@ bool ReportService::Run()
             }
         }
     }
+    else
+    {
+        spdlog::error("Failed to generate HTML.");
+    }
     return false;
-    // TODO : HTML 생성 실패 / 루프 종료 로직
 }
 
 std::vector<LogAnalysisResult> ReportService::fetchData(const std::string &fromTime, const std::string &toTime)

--- a/src/server/ReportService.h
+++ b/src/server/ReportService.h
@@ -3,14 +3,17 @@
 #include <string>
 #include <vector>
 #include "DBManager.h"
+#include "ScheduleParser.h"
 
 class ReportService {
+
 public:
     bool Run();
 
 private:
     bool loadEmailSettings(); // 변경됨: ini에서 이메일 관련 정보만 로드
     std::vector<LogAnalysisResult> fetchData(const std::string& fromTime, const std::string& toTime);
+    std::string getReportStartTime(const manlab::utils::GeneralSchedule& schedule) const;
     std::string getCurrentTimeString() const;
     bool generateHTML(const std::string& htmlFile, const std::vector<LogAnalysisResult>& events) const;
     static std::string generateColor(size_t index);
@@ -19,6 +22,6 @@ private:
     bool mbIsEnabled = false;
     std::string mRecipient;
 
-    std::string mCurrentTime;
-    std::string mLastReportTime = "2025-07-01 00:00:00"; // 추후 지속 저장 가능
+    std::string mStartTime;
+    std::string mEndTime;
 };

--- a/src/server/RsyslogManager.cpp
+++ b/src/server/RsyslogManager.cpp
@@ -133,11 +133,9 @@ void RsyslogManager::Run()
                     lar.type = result.type;
                     lar.description = result.description;
                     lar.timestamp = entry->timestamp;
-                    lar.uid = entry->hostname;
-                    lar.bIsSuccess = true;
+                    lar.username = entry->hostname;
                     lar.originalLogPath = mLogPath;
                     lar.rawLine = entry->raw;
-
                     manager.Run(lar,false);
                 }
             }

--- a/src/shared/Paths.h
+++ b/src/shared/Paths.h
@@ -63,7 +63,7 @@
 // AuditLog 디렉토리
 #define PATH_AUDITLOG "/var/log/audit/audit.log"
 
-// AuditLogRuels 디렉토리
+// AuditLogRules 디렉토리
 #define PATH_AUDITLOGRULES "/root/ManLab/conf/AuditLogRules.yaml"
 
 // 로그 리포트 저장 디렉토리


### PR DESCRIPTION
## 📌 관련 이슈

* closes #67

## ✨ 작업 내용

* spdlog를 이용한 로깅을 추가하였습니다.
* 로그 분석 리포트 표 구조를 변경하였습니다. (열 순서 변경, Event ID 1부터 시작 등)
* 리포트 조회 시작 시각(mStartTime)과 관련된 로직을 추가하였습니다.

## 🚨 중요 변경 사항 (⚠️ 필요시 체크)

* [x] LogAnalysisResult 구조체 및 관련 DB에서 IsSuccess 필드가 제거되고 UID 필드가 username으로 변경되었습니다.

## 🔍 To Reviews

* getReportStartTime() 함수의 경우 시스템 시각을 받아온 뒤 ini 파일의 type에 맞게 시간을 빼는 방식으로 구현해두었는데, 더 괜찮은 방법이 있다면 피드백 부탁 드립니다.
* 현재 로그 분석 리포트 표 구조는 아래와 같습니다. 역시 피드백 주시면 감사드리겠습니다.
<img width="1255" height="165" alt="image" src="https://github.com/user-attachments/assets/71459c69-3c0c-424e-8363-b39462ad98e5" />


## ✅ 체크리스트

* [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
* [x] Merge 하는 브랜치가 올바른가? (`main` 브랜치에 실수로 PR 생성 금지)
* [x] 팀의 코딩 컨벤션을 준수하는가?
* [x] PR과 관련 없는 변경 사항이 들어가지는 않았는가?
* [x] 내 코드에 대한 자기 검토가 충분히 되었는가?
* [x] Reviewers, Assignees, Labels, Project, Milestone은 적절하게 선택하였는가?
* [x] 관련된 issue를 닫아야 하는지 점검해보고 적용하였는가?

## 🚀 추가 코멘트
