### PR TITLE
feat : 멀티 로그 분석을 통한 명령어 사용자명 추출 및 코드 리팩토링

### DIFF
--- a/src/server/RsyslogManager.cpp
+++ b/src/server/RsyslogManager.cpp
@@ -116,10 +116,11 @@ void RsyslogManager::Run()
                 };
 
                 AnalysisResult result;
-                for (const auto& analyzer : analyzers) {
+                for (const auto& analyzer : analyzers)
+                {
+                    result = analyzer();
                     if (result.isMalicious)
                     {
-                        result = analyzer();
                         if (!result.username.empty())
                         {
                             entry->username = result.username;

--- a/src/server/RsyslogManager.cpp
+++ b/src/server/RsyslogManager.cpp
@@ -22,16 +22,11 @@ void RsyslogManager::Init(std::atomic<bool>& shouldRun)
 }
 
 // 로그 분석을 위한 timestamp 변환
-time_t RsyslogManager::ParseTime(const std::string& timestamp) {
+time_t RsyslogManager::ParseTime(const std::string& timestamp)
+{
+    std::string trimmed = timestamp.substr(0, 19); // 필요없는 부분 자르기
     struct tm tm{};
-    strptime(timestamp.c_str(), "%b %d %H:%M:%S", &tm);
-    
-    // 연도, 월 기본값 보정 (옵션)
-    time_t now = time(nullptr);
-    struct tm* now_tm = localtime(&now);
-    tm.tm_year = now_tm->tm_year;
-    tm.tm_mon = now_tm->tm_mon;
-
+    strptime(trimmed.c_str(), "%Y-%m-%dT%H:%M:%S", &tm);
     return mktime(&tm);
 }
 
@@ -73,7 +68,7 @@ std::optional<LogEntry> RsyslogManager::parseLogLine(const std::string& line)
 
     if (std::regex_match(line, match, oldFmt) || std::regex_match(line, match, newFmt))
     {
-        return LogEntry{ match[1], match[2], match[3], match[4], line };
+        return LogEntry{ match[1], match[2], "unknown", match[3], match[4], line };
     }
 
     return std::nullopt;
@@ -104,24 +99,33 @@ void RsyslogManager::Run()
                 mRecentLogs.push_back(*entry);
 
                 // 개수 기준으로 오래된 로그 삭제 (10개 초과 시 제거)
-                if (mRecentLogs.size() > MAX_RECENT_LOGS) {
+                if (mRecentLogs.size() > MAX_RECENT_LOGS)
+                {
                     mRecentLogs.pop_front();
                 }
 
-                AnalysisResult result{false, "", ""};
-                std::vector<std::function<AnalysisResult()>> analyzers = {
+                std::vector<std::function<AnalysisResult()>> analyzers =
+                {
                     [&] { return AnalyzePasswordFailureLog(*entry); },
                     [&] { return AnalyzeSudoLog(*entry, mRsyslogRuleSet["sudousers"]); },
                     [&] { return AnalyzePasswdChangeLog(*entry, mRecentLogs, mRsyslogRuleSet["passwdchangers"]); },
-                    [&] { return AnalyzeSudoGroupChangeLog(*entry); },
-                    [&] { return AnalyzeUserChangeLog(*entry); },
-                    [&] { return AnalyzeGroupChangeLog(*entry); },
-                    [&] { return AnalyzeGroupMemberChangeLog(*entry); }
+                    [&] { return AnalyzeSudoGroupChangeLog(*entry, mRecentLogs); },
+                    [&] { return AnalyzeUserChangeLog(*entry, mRecentLogs); },
+                    [&] { return AnalyzeGroupChangeLog(*entry, mRecentLogs); },
+                    [&] { return AnalyzeGroupMemberChangeLog(*entry, mRecentLogs); }
                 };
 
+                AnalysisResult result;
                 for (const auto& analyzer : analyzers) {
-                    result = analyzer();
-                    if (result.isMalicious) break;
+                    if (result.isMalicious)
+                    {
+                        result = analyzer();
+                        if (!result.username.empty())
+                        {
+                            entry->username = result.username;
+                        }
+                        break;
+                    }
                 }
 
                 if (result.isMalicious)
@@ -133,7 +137,7 @@ void RsyslogManager::Run()
                     lar.type = result.type;
                     lar.description = result.description;
                     lar.timestamp = entry->timestamp;
-                    lar.username = entry->hostname;
+                    lar.username = entry->username;
                     lar.originalLogPath = mLogPath;
                     lar.rawLine = entry->raw;
                     manager.Run(lar,false);

--- a/src/server/RsyslogManager.h
+++ b/src/server/RsyslogManager.h
@@ -12,6 +12,7 @@ struct LogEntry
 {
     std::string timestamp;
     std::string hostname;
+    std::string username;
     std::string process;
     std::string message;
     std::string raw;
@@ -23,6 +24,7 @@ struct AnalysisResult
     bool isMalicious;
     std::string type;
     std::string description;
+    std::string username;
 };
 
 class RsyslogManager

--- a/src/server/RsyslogRule.h
+++ b/src/server/RsyslogRule.h
@@ -8,7 +8,7 @@
 AnalysisResult AnalyzeSudoLog(const LogEntry& entry, const std::unordered_set<std::string>& rsyslogRuleSet);
 AnalysisResult AnalyzePasswdChangeLog(const LogEntry& entry, const std::deque<LogEntry>& recentLogs, const std::unordered_set<std::string>& rsyslogRuleSet);
 AnalysisResult AnalyzePasswordFailureLog(const LogEntry& entry);
-AnalysisResult AnalyzeSudoGroupChangeLog(const LogEntry& entry);
-AnalysisResult AnalyzeUserChangeLog(const LogEntry& entry);
-AnalysisResult AnalyzeGroupChangeLog(const LogEntry& entry);
-AnalysisResult AnalyzeGroupMemberChangeLog(const LogEntry& entry);
+AnalysisResult AnalyzeSudoGroupChangeLog(const LogEntry& entry, const std::deque<LogEntry>& recentLogs);
+AnalysisResult AnalyzeUserChangeLog(const LogEntry& entry, const std::deque<LogEntry>& recentLogs);
+AnalysisResult AnalyzeGroupChangeLog(const LogEntry& entry, const std::deque<LogEntry>& recentLogs);
+AnalysisResult AnalyzeGroupMemberChangeLog(const LogEntry& entry, const std::deque<LogEntry>& recentLogs);


### PR DESCRIPTION
## 📌 관련 이슈

*  Closes #79 

## ✨ 작업 내용

* 각 룰 별로 로그 분석 (로그 안에 username이 포함됐는지 확인)
* 포함 되지 않았을 경우 다중로그 분석을 통한 username 추출
* RsyslogRule에서 중복되는 기능 InferChanger 함수로 분리
* type에 해당되는 Mitre Rule ID 저장
* 코드 리팩토링
* DB에 저장되지 않던 오류 해결

## 🚨 중요 변경 사항 (⚠️ 필요시 체크)

* [X] DB랑 리포트에서 hostname이 아닌 username으로 저장하기로 하여 구조를 그에 맞게 수정하였습니다.

## 🔍 To Reviews

* 

## ✅ 체크리스트

* [X] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
* [X] Merge 하는 브랜치가 올바른가? (`main` 브랜치에 실수로 PR 생성 금지)
* [X] 팀의 코딩 컨벤션을 준수하는가?
* [X] PR과 관련 없는 변경 사항이 들어가지는 않았는가?
* [X] 내 코드에 대한 자기 검토가 충분히 되었는가?
* [X] Reviewers, Assignees, Labels, Project, Milestone은 적절하게 선택하였는가?
* [X] 관련된 issue를 닫아야 하는지 점검해보고 적용하였는가?

## 🚀 추가 코멘트
- string 형식으로 timestamp가 저장되어 로그 분석을 위해 time_t 형식으로 변환이 필요해서 ParseTime 함수는 유지하기로 했습니다.
- bruteforce 같은 경우 사용자가 추정되지 않는 경우가 있기에 unknown으로 표시하였습니다.