### PR TITLE
fix : 베이스라인 생성시 modifiedhash.db 초기화 로직 추가

### DIFF
--- a/src/server/FIMBaselineGenerator.cpp
+++ b/src/server/FIMBaselineGenerator.cpp
@@ -86,6 +86,9 @@ void BaselineGenerator::parse_ini_and_store(std::ostream& out) {
     }
 
     auto& storage = DBManager::GetInstance().GetBaselineStorage();
+
+    DBManager::GetInstance().GetModifiedStorage().remove_all<ModifiedEntry>();
+    
     std::vector<std::string> target_paths;
     std::unordered_set<std::string> exclude_paths;
 


### PR DESCRIPTION
## 📌 관련 이슈

* 여러번 탐지 시도했을때 오탐 오류 해결

## ✨ 작업 내용

* baseline 생성 시 modifiedhash DB는 초기화 됩니다.

## 🚨 중요 변경 사항 (⚠️ 필요시 체크)

* [ ] 

## 🔍 To Reviews

* 

## ✅ 체크리스트

* [ ] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
* [ ] Merge 하는 브랜치가 올바른가? (`main` 브랜치에 실수로 PR 생성 금지)
* [ ] 팀의 코딩 컨벤션을 준수하는가?
* [ ] PR과 관련 없는 변경 사항이 들어가지는 않았는가?
* [ ] 내 코드에 대한 자기 검토가 충분히 되었는가?
* [ ] Reviewers, Assignees, Labels, Project, Milestone은 적절하게 선택하였는가?
* [ ] 관련된 issue를 닫아야 하는지 점검해보고 적용하였는가?

## 🚀 추가 코멘트
