### PR TITLE
feat: 리포트 시각화 추가

### DIFF
--- a/src/server/GmailClient.cpp
+++ b/src/server/GmailClient.cpp
@@ -81,7 +81,7 @@ bool GmailClient::Run(const std::string &file)
         CURLcode res = curl_easy_perform(mCurl);
         if (res != CURLE_OK)
         {
-            spdlog::error("curl_easy_perform() failed: ", curl_easy_strerror(res));
+            spdlog::error("curl_easy_perform() failed: {}", std::string(curl_easy_strerror(res)));
             curl_slist_free_all(recipients);
             curl_slist_free_all(headers);
             curl_mime_free(mime);

--- a/src/server/ScheduleWatcher.cpp
+++ b/src/server/ScheduleWatcher.cpp
@@ -78,8 +78,8 @@ void ScheduleWatcher::Run()
 
         // 리포트 조건 체크
         {
-            spdlog::debug("리포트 설정 파일 로딩 중: {}", PATH_LOG_REPORT_INI);
-            INIReader reader(PATH_LOG_REPORT_INI);
+            spdlog::debug("리포트 설정 파일 로딩 중: {}", PATH_REPORT_INI);
+            INIReader reader(PATH_REPORT_INI);
             if (reader.ParseError() != 0)
             {
                 spdlog::warn("리포트 INI 파싱 실패");

--- a/src/shared/Paths.h
+++ b/src/shared/Paths.h
@@ -45,8 +45,8 @@
 // 예약검사 설정파일
 #define PATH_SCHEDUL_CONFIG_INI "/root/ManLab/conf/ScanSchedul.ini"
 
-// 로그 리포트 설정파일
-# define PATH_LOG_REPORT_INI  "/root/ManLab/conf/ReportConfig.ini"
+// 리포트 설정파일
+# define PATH_REPORT_INI  "/root/ManLab/conf/ReportConfig.ini"
 
 // rules 디렉토리
 #define PATH_RULES "/root/ManLab/rules"


### PR DESCRIPTION
## 📌 관련 이슈

* closes #82 

## ✨ 작업 내용

* 조회된 이벤트가 없을 때 빈 도넛 차트가 출력되지 않도록 변경하였습니다.
* '상세 로그 테이블'에서 Event ID 클릭 시 해당되는 원본 로그로 이동하는 하이퍼링크를 추가하고 하이라이팅을 추가하였습니다.
* '탐지된 악성 행위 타입 개요' 도넛 차트 클릭 시 해당되는 악성 행위 타입의 '상세 로그'에 대한 하이라이팅을 추가하였습니다.
* 리포트 타이틀을 ManLab Regular Report로 변경하였습니다.
* 제목, 차트, 날짜 정렬 위치를 변경하였습니다.
* 리포트 설정 파일 관련 상수명을 변경하였습니다.
* 메일 전송 관련 에러 로깅이 제대로 되지 않던 문제를 해결하였습니다.

(도넛 차트 'brute_force_password_failure' 영역 클릭 시)
<img width="1741" height="790" alt="image" src="https://github.com/user-attachments/assets/11c63df4-bfa5-4131-80d0-c5ac20a78aa0" />
('상세 로그 테이블' Event ID 1 클릭 시)
<img width="1744" height="1138" alt="image" src="https://github.com/user-attachments/assets/147dd6a7-5ab7-48a1-bc25-13c26760b9e2" />

## 🚨 중요 변경 사항 (⚠️ 필요시 체크)

- [x] Paths.h 파일의 리포트 설정 파일 관련 상수명을 변경하였습니다.

## 🔍 To Reviews

* 도넛 차트 클릭 시 onClick이 실행되고, label을 결정하여 highlightRow(label)을 호출함으로써 하이라이팅을 처리하였습니다.

## ✅ 체크리스트

* [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
* [x] Merge 하는 브랜치가 올바른가? (`main` 브랜치에 실수로 PR 생성 금지)
* [x] 팀의 코딩 컨벤션을 준수하는가?
* [x] PR과 관련 없는 변경 사항이 들어가지는 않았는가?
* [x] 내 코드에 대한 자기 검토가 충분히 되었는가?
* [x] Reviewers, Assignees, Labels, Project, Milestone은 적절하게 선택하였는가?
* [x] 관련된 issue를 닫아야 하는지 점검해보고 적용하였는가?

## 🚀 추가 코멘트
* 팀별 리포트 처리 로직을 통일하는 것이 좋을 것 같습니다. (DB에서 데이터를 가져오는 부분 등)
* 추가 수정이 필요한 부분 코멘트 부탁 드립니다.